### PR TITLE
Apply no-console-resets clarification to other categories that ban it

### DIFF
--- a/Main Board/Variables/Misc/Cane of Byrna.md
+++ b/Main Board/Variables/Misc/Cane of Byrna.md
@@ -3,4 +3,4 @@
 **This category follows the [NMG Ruleset](https://www.speedrun.com/alttp?h=No_Major_Glitches-Any&rules=category&x=wk6jz5rd-2lg2368p.013xwzr1)**
 
 1. Timing starts on file select and ends upon collecting the Cane of Byrna.
-2. Save & Quit, including intentionally dying on the overworld to emulate a Save & Quit, is banned.
+2. **Save & Quit is banned. Intentionally dying on the overworld to emulate a Save & Quit is banned. Similarly, console resets (soft and hard) are banned.**

--- a/Main Board/Variables/Misc/Mirror Shield.md
+++ b/Main Board/Variables/Misc/Mirror Shield.md
@@ -3,4 +3,4 @@
 **This category follows the [NMG Ruleset](https://www.speedrun.com/alttp?h=No_Major_Glitches-Any&rules=category&x=wk6jz5rd-2lg2368p.013xwzr1)**
 
 1. Timing starts on file select and ends upon collecting the Mirror Shield.
-2. Save & Quit, including intentionally dying on the overworld to emulate a Save & Quit, is banned.
+2. **Save & Quit is banned. Intentionally dying on the overworld to emulate a Save & Quit is banned. Similarly, console resets (soft and hard) are banned.**

--- a/Main Board/Variables/No Major Glitches/100%.md
+++ b/Main Board/Variables/No Major Glitches/100%.md
@@ -2,7 +2,7 @@
 
 1. Timing starts on file select and ends upon entering the Triforce room.
 
-2. Save & Quit, including intentionally dying on the overworld to emulate a Save & Quit, is banned.
+2. **Save & Quit is banned. Intentionally dying on the overworld to emulate a Save & Quit is banned. Similarly, console resets (soft and hard) are banned.**
 
 3. This requires a full inventory with all maximum level items, 20 hearts and 1/2 magic. Intermediary upgrades and the bomb/arrow upgrades are not required.
 

--- a/Main Board/Variables/No Major Glitches/Low% Legacy.md
+++ b/Main Board/Variables/No Major Glitches/Low% Legacy.md
@@ -2,7 +2,7 @@
 
 1. Timing starts on file select and ends upon entering the Triforce room.
 
-2. Save & Quit, including intentionally dying on the overworld to emulate a Save & Quit, is banned.
+2. **Save & Quit is banned. Intentionally dying on the overworld to emulate a Save & Quit is banned. Similarly, console resets (soft and hard) are banned.**
 
 3. You must skip all items and upgrades which are not essential to beat the game.
 

--- a/Main Board/Variables/No Major Glitches/Low%.md
+++ b/Main Board/Variables/No Major Glitches/Low%.md
@@ -2,6 +2,6 @@
 
 1. Timing starts on file select and ends upon entering the Triforce room.
 
-2. Save & Quit, including intentionally dying on the overworld to emulate a Save & Quit, is banned.
+2. **Save & Quit is banned. Intentionally dying on the overworld to emulate a Save & Quit is banned. Similarly, console resets (soft and hard) are banned.**
 
 3. You must skip all items and upgrades which are not essential to beat the game. You must finish with 3 heart containers.


### PR DESCRIPTION
Updates the other categories which ban S&Q with the "no console resets" clarification.